### PR TITLE
[java] defer vector capacity checks for nested complex types

### DIFF
--- a/cpp/src/arrow/compute/key_hash.h
+++ b/cpp/src/arrow/compute/key_hash.h
@@ -51,10 +51,10 @@ class ARROW_EXPORT Hashing32 {
   static Status HashBatch(const ExecBatch& key_batch, uint32_t* hashes,
                           std::vector<KeyColumnArray>& column_arrays,
                           int64_t hardware_flags, util::TempVectorStack* temp_stack,
-                          int64_t offset, int64_t length);
+                          int64_t start_row, int64_t num_rows);
 
   static void HashFixed(int64_t hardware_flags, bool combine_hashes, uint32_t num_keys,
-                        uint64_t length_key, const uint8_t* keys, uint32_t* hashes,
+                        uint64_t key_length, const uint8_t* keys, uint32_t* hashes,
                         uint32_t* temp_hashes_for_combine);
 
  private:
@@ -100,7 +100,7 @@ class ARROW_EXPORT Hashing32 {
   static inline void StripeMask(int i, uint32_t* mask1, uint32_t* mask2, uint32_t* mask3,
                                 uint32_t* mask4);
   template <bool T_COMBINE_HASHES>
-  static void HashFixedLenImp(uint32_t num_rows, uint64_t length, const uint8_t* keys,
+  static void HashFixedLenImp(uint32_t num_rows, uint64_t key_length, const uint8_t* keys,
                               uint32_t* hashes);
   template <typename T, bool T_COMBINE_HASHES>
   static void HashVarLenImp(uint32_t num_rows, const T* offsets,
@@ -112,7 +112,7 @@ class ARROW_EXPORT Hashing32 {
                       const uint8_t* keys, uint32_t* hashes);
   template <bool T_COMBINE_HASHES, typename T>
   static void HashIntImp(uint32_t num_keys, const T* keys, uint32_t* hashes);
-  static void HashInt(bool combine_hashes, uint32_t num_keys, uint64_t length_key,
+  static void HashInt(bool combine_hashes, uint32_t num_keys, uint64_t key_length,
                       const uint8_t* keys, uint32_t* hashes);
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
@@ -129,11 +129,11 @@ class ARROW_EXPORT Hashing32 {
                                             __m256i mask_last_stripe, const uint8_t* keys,
                                             int64_t offset_A, int64_t offset_B);
   template <bool T_COMBINE_HASHES>
-  static uint32_t HashFixedLenImp_avx2(uint32_t num_rows, uint64_t length,
+  static uint32_t HashFixedLenImp_avx2(uint32_t num_rows, uint64_t key_length,
                                        const uint8_t* keys, uint32_t* hashes,
                                        uint32_t* hashes_temp_for_combine);
   static uint32_t HashFixedLen_avx2(bool combine_hashes, uint32_t num_rows,
-                                    uint64_t length, const uint8_t* keys,
+                                    uint64_t key_length, const uint8_t* keys,
                                     uint32_t* hashes, uint32_t* hashes_temp_for_combine);
   template <typename T, bool T_COMBINE_HASHES>
   static uint32_t HashVarLenImp_avx2(uint32_t num_rows, const T* offsets,
@@ -164,9 +164,9 @@ class ARROW_EXPORT Hashing64 {
   static Status HashBatch(const ExecBatch& key_batch, uint64_t* hashes,
                           std::vector<KeyColumnArray>& column_arrays,
                           int64_t hardware_flags, util::TempVectorStack* temp_stack,
-                          int64_t offset, int64_t length);
+                          int64_t start_row, int64_t num_rows);
 
-  static void HashFixed(bool combine_hashes, uint32_t num_keys, uint64_t length_key,
+  static void HashFixed(bool combine_hashes, uint32_t num_keys, uint64_t key_length,
                         const uint8_t* keys, uint64_t* hashes);
 
  private:
@@ -203,7 +203,7 @@ class ARROW_EXPORT Hashing64 {
   static inline void StripeMask(int i, uint64_t* mask1, uint64_t* mask2, uint64_t* mask3,
                                 uint64_t* mask4);
   template <bool T_COMBINE_HASHES>
-  static void HashFixedLenImp(uint32_t num_rows, uint64_t length, const uint8_t* keys,
+  static void HashFixedLenImp(uint32_t num_rows, uint64_t key_length, const uint8_t* keys,
                               uint64_t* hashes);
   template <typename T, bool T_COMBINE_HASHES>
   static void HashVarLenImp(uint32_t num_rows, const T* offsets,
@@ -211,11 +211,11 @@ class ARROW_EXPORT Hashing64 {
   template <bool T_COMBINE_HASHES>
   static void HashBitImp(int64_t bit_offset, uint32_t num_keys, const uint8_t* keys,
                          uint64_t* hashes);
-  static void HashBit(bool T_COMBINE_HASHES, int64_t bit_offset, uint32_t num_keys,
+  static void HashBit(bool combine_hashes, int64_t bit_offset, uint32_t num_keys,
                       const uint8_t* keys, uint64_t* hashes);
   template <bool T_COMBINE_HASHES, typename T>
   static void HashIntImp(uint32_t num_keys, const T* keys, uint64_t* hashes);
-  static void HashInt(bool T_COMBINE_HASHES, uint32_t num_keys, uint64_t length_key,
+  static void HashInt(bool combine_hashes, uint32_t num_keys, uint64_t key_length,
                       const uint8_t* keys, uint64_t* hashes);
 };
 

--- a/cpp/src/arrow/compute/key_hash_avx2.cc
+++ b/cpp/src/arrow/compute/key_hash_avx2.cc
@@ -190,7 +190,7 @@ uint32_t Hashing32::HashFixedLenImp_avx2(uint32_t num_rows, uint64_t length,
   // Do not process rows that could read past the end of the buffer using 16
   // byte loads. Round down number of rows to process to multiple of 2.
   //
-  uint64_t num_rows_to_skip = bit_util::CeilDiv(length, kStripeSize);
+  uint64_t num_rows_to_skip = bit_util::CeilDiv(kStripeSize, length);
   uint32_t num_rows_to_process =
       (num_rows_to_skip > num_rows)
           ? 0

--- a/cpp/src/arrow/compute/key_hash_test.cc
+++ b/cpp/src/arrow/compute/key_hash_test.cc
@@ -252,5 +252,64 @@ TEST(VectorHash, BasicString) { RunTestVectorHash<StringType>(); }
 
 TEST(VectorHash, BasicLargeString) { RunTestVectorHash<LargeStringType>(); }
 
+void HashFixedLengthFrom(int key_length, int num_rows, int start_row) {
+  int num_rows_to_hash = num_rows - start_row;
+  auto num_bytes_aligned = arrow::bit_util::RoundUpToMultipleOf64(key_length * num_rows);
+
+  const auto hardware_flags_for_testing = HardwareFlagsForTesting();
+  ASSERT_GT(hardware_flags_for_testing.size(), 0);
+
+  std::vector<std::vector<uint32_t>> hashes32(hardware_flags_for_testing.size());
+  std::vector<std::vector<uint64_t>> hashes64(hardware_flags_for_testing.size());
+  for (auto& h : hashes32) {
+    h.resize(num_rows_to_hash);
+  }
+  for (auto& h : hashes64) {
+    h.resize(num_rows_to_hash);
+  }
+
+  FixedSizeBinaryBuilder keys_builder(fixed_size_binary(key_length));
+  for (int j = 0; j < num_rows; ++j) {
+    ASSERT_OK(keys_builder.Append(std::string(key_length, 42)));
+  }
+  ASSERT_OK_AND_ASSIGN(auto keys, keys_builder.Finish());
+  // Make sure the buffer is aligned as expected.
+  ASSERT_EQ(keys->data()->buffers[1]->capacity(), num_bytes_aligned);
+
+  constexpr int mini_batch_size = 1024;
+  std::vector<uint32_t> temp_buffer;
+  temp_buffer.resize(mini_batch_size * 4);
+
+  for (int i = 0; i < static_cast<int>(hardware_flags_for_testing.size()); ++i) {
+    const auto hardware_flags = hardware_flags_for_testing[i];
+    Hashing32::HashFixed(hardware_flags,
+                         /*combine_hashes=*/false, num_rows_to_hash, key_length,
+                         keys->data()->GetValues<uint8_t>(1) + start_row * key_length,
+                         hashes32[i].data(), temp_buffer.data());
+    Hashing64::HashFixed(
+        /*combine_hashes=*/false, num_rows_to_hash, key_length,
+        keys->data()->GetValues<uint8_t>(1) + start_row * key_length, hashes64[i].data());
+  }
+
+  // Verify that all implementations (scalar, SIMD) give the same hashes.
+  for (int i = 1; i < static_cast<int>(hardware_flags_for_testing.size()); ++i) {
+    for (int j = 0; j < num_rows_to_hash; ++j) {
+      ASSERT_EQ(hashes32[i][j], hashes32[0][j])
+          << "scalar and simd approaches yielded different 32-bit hashes";
+      ASSERT_EQ(hashes64[i][j], hashes64[0][j])
+          << "scalar and simd approaches yielded different 64-bit hashes";
+    }
+  }
+}
+
+// Some carefully chosen cases that may cause troubles like GH-39778.
+TEST(VectorHash, FixedLengthTailByteSafety) {
+  // Tow cases of key_length < stripe (16-byte).
+  HashFixedLengthFrom(/*key_length=*/3, /*num_rows=*/1450, /*start_row=*/1447);
+  HashFixedLengthFrom(/*key_length=*/5, /*num_rows=*/883, /*start_row=*/858);
+  // Case of key_length > stripe (16-byte).
+  HashFixedLengthFrom(/*key_length=*/19, /*num_rows=*/64, /*start_row=*/63);
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_benchmark.cc
+++ b/cpp/src/arrow/dataset/file_benchmark.cc
@@ -66,7 +66,7 @@ static void GetAllFragments(benchmark::State& state) {
     ABORT_NOT_OK(fragments.Visit([](std::shared_ptr<Fragment>) { return Status::OK(); }));
   }
   state.SetItemsProcessed(state.iterations() * dataset.num_fragments);
-  state.counters["num_fragments"] = dataset.num_fragments;
+  state.counters["num_fragments"] = static_cast<double>(dataset.num_fragments);
 }
 
 static void GetFilteredFragments(benchmark::State& state, compute::Expression filter) {
@@ -82,8 +82,8 @@ static void GetFilteredFragments(benchmark::State& state, compute::Expression fi
     }));
   }
   state.SetItemsProcessed(state.iterations() * dataset.num_fragments);
-  state.counters["num_fragments"] = dataset.num_fragments;
-  state.counters["num_filtered_fragments"] = num_filtered_fragments;
+  state.counters["num_fragments"] = static_cast<double>(dataset.num_fragments);
+  state.counters["num_filtered_fragments"] = static_cast<double>(num_filtered_fragments);
 }
 
 using compute::field_ref;

--- a/cpp/src/arrow/dataset/file_benchmark.cc
+++ b/cpp/src/arrow/dataset/file_benchmark.cc
@@ -30,7 +30,12 @@
 namespace arrow {
 namespace dataset {
 
-static std::shared_ptr<Dataset> GetDataset() {
+struct SampleDataset {
+  std::shared_ptr<Dataset> dataset;
+  int64_t num_fragments;
+};
+
+static SampleDataset GetDataset() {
   std::vector<fs::FileInfo> files;
   std::vector<std::string> paths;
   for (int a = 0; a < 100; a++) {
@@ -50,25 +55,35 @@ static std::shared_ptr<Dataset> GetDataset() {
   FinishOptions finish_options;
   finish_options.inspect_options.fragments = 0;
   EXPECT_OK_AND_ASSIGN(auto dataset, factory->Finish(finish_options));
-  return dataset;
+  return {dataset, static_cast<int64_t>(paths.size())};
 }
 
 // A benchmark of filtering fragments in a dataset.
 static void GetAllFragments(benchmark::State& state) {
   auto dataset = GetDataset();
   for (auto _ : state) {
-    ASSERT_OK_AND_ASSIGN(auto fragments, dataset->GetFragments());
+    ASSERT_OK_AND_ASSIGN(auto fragments, dataset.dataset->GetFragments());
     ABORT_NOT_OK(fragments.Visit([](std::shared_ptr<Fragment>) { return Status::OK(); }));
   }
+  state.SetItemsProcessed(state.iterations() * dataset.num_fragments);
+  state.counters["num_fragments"] = dataset.num_fragments;
 }
 
 static void GetFilteredFragments(benchmark::State& state, compute::Expression filter) {
   auto dataset = GetDataset();
-  ASSERT_OK_AND_ASSIGN(filter, filter.Bind(*dataset->schema()));
+  ASSERT_OK_AND_ASSIGN(filter, filter.Bind(*dataset.dataset->schema()));
+  int64_t num_filtered_fragments = 0;
   for (auto _ : state) {
-    ASSERT_OK_AND_ASSIGN(auto fragments, dataset->GetFragments(filter));
-    ABORT_NOT_OK(fragments.Visit([](std::shared_ptr<Fragment>) { return Status::OK(); }));
+    num_filtered_fragments = 0;
+    ASSERT_OK_AND_ASSIGN(auto fragments, dataset.dataset->GetFragments(filter));
+    ABORT_NOT_OK(fragments.Visit([&](std::shared_ptr<Fragment>) {
+      ++num_filtered_fragments;
+      return Status::OK();
+    }));
   }
+  state.SetItemsProcessed(state.iterations() * dataset.num_fragments);
+  state.counters["num_fragments"] = dataset.num_fragments;
+  state.counters["num_filtered_fragments"] = num_filtered_fragments;
 }
 
 using compute::field_ref;

--- a/cpp/src/arrow/dataset/scanner_benchmark.cc
+++ b/cpp/src/arrow/dataset/scanner_benchmark.cc
@@ -162,7 +162,11 @@ void ScanOnly(
                        acero::DeclarationToTable(std::move(scan)));
 
   ASSERT_GT(collected->num_rows(), 0);
-  ASSERT_EQ(collected->num_columns(), 2);
+  if (factory_name == "scan") {
+    ASSERT_EQ(collected->num_columns(), 6);
+  } else if (factory_name == "scan2") {
+    ASSERT_EQ(collected->num_columns(), 2);
+  }
 }
 
 static constexpr int kScanIdx = 0;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -271,7 +271,12 @@ class SerializedPageWriter : public PageWriter {
   }
 
   int64_t WriteDictionaryPage(const DictionaryPage& page) override {
-    int64_t uncompressed_size = page.size();
+    int64_t uncompressed_size = page.buffer()->size();
+    if (uncompressed_size > std::numeric_limits<int32_t>::max()) {
+      throw ParquetException(
+          "Uncompressed dictionary page size overflows INT32_MAX. Size:",
+          uncompressed_size);
+    }
     std::shared_ptr<Buffer> compressed_data;
     if (has_compressor()) {
       auto buffer = std::static_pointer_cast<ResizableBuffer>(
@@ -288,6 +293,11 @@ class SerializedPageWriter : public PageWriter {
     dict_page_header.__set_is_sorted(page.is_sorted());
 
     const uint8_t* output_data_buffer = compressed_data->data();
+    if (compressed_data->size() > std::numeric_limits<int32_t>::max()) {
+      throw ParquetException(
+          "Compressed dictionary page size overflows INT32_MAX. Size: ",
+          uncompressed_size);
+    }
     int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
 
     if (data_encryptor_.get()) {
@@ -371,18 +381,29 @@ class SerializedPageWriter : public PageWriter {
     const int64_t uncompressed_size = page.uncompressed_size();
     std::shared_ptr<Buffer> compressed_data = page.buffer();
     const uint8_t* output_data_buffer = compressed_data->data();
-    int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
+    int64_t output_data_len = compressed_data->size();
+
+    if (output_data_len > std::numeric_limits<int32_t>::max()) {
+      throw ParquetException("Compressed data page size overflows INT32_MAX. Size:",
+                             output_data_len);
+    }
 
     if (data_encryptor_.get()) {
       PARQUET_THROW_NOT_OK(encryption_buffer_->Resize(
           data_encryptor_->CiphertextSizeDelta() + output_data_len, false));
       UpdateEncryption(encryption::kDataPage);
-      output_data_len = data_encryptor_->Encrypt(compressed_data->data(), output_data_len,
+      output_data_len = data_encryptor_->Encrypt(compressed_data->data(),
+                                                 static_cast<int32_t>(output_data_len),
                                                  encryption_buffer_->mutable_data());
       output_data_buffer = encryption_buffer_->data();
     }
 
     format::PageHeader page_header;
+
+    if (uncompressed_size > std::numeric_limits<int32_t>::max()) {
+      throw ParquetException("Uncompressed data page size overflows INT32_MAX. Size:",
+                             uncompressed_size);
+    }
     page_header.__set_uncompressed_page_size(static_cast<int32_t>(uncompressed_size));
     page_header.__set_compressed_page_size(static_cast<int32_t>(output_data_len));
 
@@ -421,7 +442,7 @@ class SerializedPageWriter : public PageWriter {
     if (offset_index_builder_ != nullptr) {
       const int64_t compressed_size = output_data_len + header_size;
       if (compressed_size > std::numeric_limits<int32_t>::max()) {
-        throw ParquetException("Compressed page size overflows to INT32_MAX.");
+        throw ParquetException("Compressed page size overflows INT32_MAX.");
       }
       if (!page.first_row_index().has_value()) {
         throw ParquetException("First row index is not set in data page.");

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -198,6 +198,15 @@ class PostBumpVersionsTest < Test::Unit::TestCase
     if release_type == :major
       expected_changes += [
         {
+          path: "docs/source/index.rst",
+          hunks: [
+            [
+              "-   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}>",
+              "+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}>",
+            ],
+          ],
+        },
+        {
           path: "r/pkgdown/assets/versions.json",
           hunks: [
             [
@@ -209,6 +218,15 @@ class PostBumpVersionsTest < Test::Unit::TestCase
               "+        \"name\": \"#{@previous_r_version}\",",
               "+        \"version\": \"#{@previous_compatible_version}/\"",
               "+    },",
+            ],
+          ],
+        },
+        {
+          path: "r/_pkgdown.yml",
+          hunks: [
+            [
+              "-          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@snapshot_major_version}) <br>",
+              "+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v#{@next_major_version}) <br>",
             ],
           ],
         },

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -127,6 +127,7 @@ update_versions() {
     DESCRIPTION
   rm -f DESCRIPTION.bak
   git add DESCRIPTION
+  
   # Replace dev version with release version
   sed -i.bak -E -e \
     "/^<!--/,/^# arrow /s/^# arrow .+/# arrow ${base_version}/" \
@@ -139,6 +140,13 @@ update_versions() {
   fi
   rm -f NEWS.md.bak
   git add NEWS.md
+
+  # godoc link must reference current version, will reference v0.0.0 (2018) otherwise
+  sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" \
+    _pkgdown.yml
+  rm -f _pkgdown.yml.bak
+  git add _pkgdown.yml
   popd
 
   pushd "${ARROW_DIR}/ruby"
@@ -162,6 +170,15 @@ update_versions() {
 
   find . -name "*.bak" -exec rm {} \;
   git add .
+  popd
+
+  pushd "${ARROW_DIR}/docs/source"
+  # godoc link must reference current version, will reference v0.0.0 (2018) otherwise
+  sed -i.bak -E -e \
+    "s|(github\\.com/apache/arrow/go)/v[0-9]+|\1/v${major_version}|g" \
+    index.rst
+  rm -f index.rst.bak
+  git add index.rst
   popd
 
   pushd "${ARROW_DIR}"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -104,7 +104,7 @@ Implementations
    C/GLib <c_glib/index>
    C++ <cpp/index>
    C# <https://github.com/apache/arrow/blob/main/csharp/README.md>
-   Go <https://pkg.go.dev/github.com/apache/arrow/go>
+   Go <https://pkg.go.dev/github.com/apache/arrow/go/v16>
    Java <java/index>
    JavaScript <js/index>
    Julia <https://arrow.apache.org/julia/>

--- a/go/arrow/flight/flightsql/client.go
+++ b/go/arrow/flight/flightsql/client.go
@@ -1165,6 +1165,9 @@ func (p *PreparedStatement) DatasetSchema() *arrow.Schema { return p.datasetSche
 // the prepared statement.
 func (p *PreparedStatement) ParameterSchema() *arrow.Schema { return p.paramSchema }
 
+// The handle associated with this PreparedStatement
+func (p *PreparedStatement) Handle() []byte { return p.handle }
+
 // GetSchema re-requests the schema of the result set of the prepared
 // statement from the server. It should otherwise be identical to DatasetSchema.
 //

--- a/go/arrow/flight/flightsql/client_test.go
+++ b/go/arrow/flight/flightsql/client_test.go
@@ -384,6 +384,8 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecute() {
 	s.NoError(err)
 	defer prepared.Close(context.TODO(), s.callOpts...)
 
+	s.Equal(string(prepared.Handle()), "query")
+
 	info, err := prepared.Execute(context.TODO(), s.callOpts...)
 	s.NoError(err)
 	s.Equal(&emptyFlightInfo, info)
@@ -445,10 +447,14 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteParamBinding() {
 	s.NoError(err)
 	defer prepared.Close(context.TODO(), s.callOpts...)
 
+	s.Equal(string(prepared.Handle()), "query")
+
 	paramSchema := prepared.ParameterSchema()
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, paramSchema, strings.NewReader(`[{"id": 1}]`))
 	s.NoError(err)
 	defer rec.Release()
+
+	s.Equal(string(prepared.Handle()), "query")
 
 	prepared.SetParameters(rec)
 	info, err := prepared.Execute(context.TODO(), s.callOpts...)
@@ -517,6 +523,8 @@ func (s *FlightSqlClientSuite) TestPreparedStatementExecuteReaderBinding() {
 	s.NoError(err)
 	defer prepared.Close(context.TODO(), s.callOpts...)
 
+	s.Equal(string(prepared.Handle()), "query")
+
 	paramSchema := prepared.ParameterSchema()
 	rec, _, err := array.RecordFromJSON(memory.DefaultAllocator, paramSchema, strings.NewReader(`[{"id": 1}]`))
 	s.NoError(err)
@@ -575,6 +583,8 @@ func (s *FlightSqlClientSuite) TestPreparedStatementClose() {
 
 	err = prepared.Close(context.TODO(), s.callOpts...)
 	s.NoError(err)
+
+	s.Equal(string(prepared.Handle()), "query")
 }
 
 func (s *FlightSqlClientSuite) TestExecuteUpdate() {

--- a/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroArraysConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroArraysConsumer.java
@@ -19,7 +19,12 @@ package org.apache.arrow.adapter.avro.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.AbstractContainerVector;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.RepeatedValueVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -67,8 +72,12 @@ public class AvroArraysConsumer extends BaseAvroConsumer<ListVector> {
   }
 
   void ensureInnerVectorCapacity(long targetCapacity) {
-    while (vector.getDataVector().getValueCapacity() < targetCapacity) {
-      vector.getDataVector().reAlloc();
+    FieldVector elementVec = vector.getDataVector();
+    if (!(elementVec instanceof RepeatedValueVector
+            || elementVec instanceof AbstractContainerVector)) {
+      while (vector.getDataVector().getValueCapacity() < targetCapacity) {
+        vector.getDataVector().reAlloc();
+      }
     }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroStructConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroStructConsumer.java
@@ -21,7 +21,10 @@ import java.io.IOException;
 
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.AbstractContainerVector;
+import org.apache.arrow.vector.complex.RepeatedValueVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.Types;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -68,8 +71,11 @@ public class AvroStructConsumer extends BaseAvroConsumer<StructVector> {
 
   void ensureInnerVectorCapacity(long targetCapacity) {
     for (FieldVector v : vector.getChildrenFromFields()) {
-      while (v.getValueCapacity() < targetCapacity) {
-        v.reAlloc();
+      if (!(v instanceof RepeatedValueVector
+              || v instanceof AbstractContainerVector)) {
+        while (v.getValueCapacity() < targetCapacity) {
+          v.reAlloc();
+        }
       }
     }
   }

--- a/java/adapter/avro/src/test/resources/schema/test_nested_union.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nested_union.avsc
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+  "namespace": "org.apache.arrow.avro",
+  "type": "record",
+  "name": "testArrayOfRecords",
+  "fields": [
+    {
+      "name": "f0",
+      "type": {
+        "type": "record",
+        "name": "NestedRecord",
+        "fields": [
+          {
+            "name": "fUnionInRecord",
+            "type": ["null", "int"],
+            "default": null
+          },
+          {
+            "name": "fUnionInArray",
+            "type" : {
+              "type": "array",
+              "items": [
+                "null",
+                "int"
+              ]
+            }
+          },
+          {
+            "name": "fUnionInArrayOfRecords",
+            "type" : {
+              "type": "array",
+              "items": {
+                "type": "record",
+                "name": "RecordWithUnionField",
+                "fields": [
+                  {
+                    "name": "f1",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -76,7 +76,7 @@ home:
           [C GLib](https://arrow.apache.org/docs/c_glib) <br>
           [C++](https://arrow.apache.org/docs/cpp) <br>
           [C#](https://github.com/apache/arrow/blob/main/csharp/README.md) <br>
-          [Go](https://pkg.go.dev/github.com/apache/arrow/go) <br>
+          [Go](https://pkg.go.dev/github.com/apache/arrow/go/v16) <br>
           [Java](https://arrow.apache.org/docs/java) <br>
           [JavaScript](https://arrow.apache.org/docs/js) <br>
           [Julia](https://github.com/apache/arrow-julia/blob/main/README.md) <br>

--- a/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowArrayBuilder.swift
@@ -36,12 +36,12 @@ public class ArrowArrayBuilder<T: ArrowBufferBuilder, U: ArrowArray<T.ItemType>>
 
     public func finish() throws -> ArrowArray<T.ItemType> {
         let buffers = self.bufferBuilder.finish()
-        let arrowData = try ArrowData(self.type, buffers: buffers, nullCount: self.nullCount, stride: self.getStride())
+        let arrowData = try ArrowData(self.type, buffers: buffers, nullCount: self.nullCount)
         return U(arrowData)
     }
 
     public func getStride() -> Int {
-        MemoryLayout<T.ItemType>.stride
+        return self.type.getStride()
     }
 }
 
@@ -73,19 +73,11 @@ public class Date32ArrayBuilder: ArrowArrayBuilder<Date32BufferBuilder, Date32Ar
     fileprivate convenience init() throws {
         try self.init(ArrowType(ArrowType.ArrowDate32))
     }
-
-    public override func getStride() -> Int {
-        MemoryLayout<Int32>.stride
-    }
 }
 
 public class Date64ArrayBuilder: ArrowArrayBuilder<Date64BufferBuilder, Date64Array> {
     fileprivate convenience init() throws {
         try self.init(ArrowType(ArrowType.ArrowDate64))
-    }
-
-    public override func getStride() -> Int {
-        MemoryLayout<Int64>.stride
     }
 }
 

--- a/swift/Arrow/Sources/Arrow/ArrowData.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowData.swift
@@ -24,7 +24,7 @@ public class ArrowData {
     public let length: UInt
     public let stride: Int
 
-    init(_ arrowType: ArrowType, buffers: [ArrowBuffer], nullCount: UInt, stride: Int) throws {
+    init(_ arrowType: ArrowType, buffers: [ArrowBuffer], nullCount: UInt) throws {
         let infoType = arrowType.info
         switch infoType {
         case let .primitiveInfo(typeId):
@@ -45,7 +45,7 @@ public class ArrowData {
         self.buffers = buffers
         self.nullCount = nullCount
         self.length = buffers[1].length
-        self.stride = stride
+        self.stride = arrowType.getStride()
     }
 
     public func isNull(_ at: UInt) -> Bool {

--- a/swift/Arrow/Sources/Arrow/ArrowType.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowType.swift
@@ -19,6 +19,8 @@ import Foundation
 
 public typealias Time32 = Int32
 public typealias Time64 = Int64
+public typealias Date32 = Int32
+public typealias Date64 = Int64
 
 func FlatBuffersVersion_23_1_4() { // swiftlint:disable:this identifier_name
 }
@@ -163,6 +165,48 @@ public class ArrowType {
             return ArrowType.ArrowDouble
         } else {
             return ArrowType.ArrowUnknown
+        }
+    }
+
+    public func getStride( // swiftlint:disable:this cyclomatic_complexity
+    ) -> Int {
+        switch self.id {
+        case .int8:
+            return MemoryLayout<Int8>.stride
+        case .int16:
+            return MemoryLayout<Int16>.stride
+        case .int32:
+            return MemoryLayout<Int32>.stride
+        case .int64:
+            return MemoryLayout<Int64>.stride
+        case .uint8:
+            return MemoryLayout<UInt8>.stride
+        case .uint16:
+            return MemoryLayout<UInt16>.stride
+        case .uint32:
+            return MemoryLayout<UInt32>.stride
+        case .uint64:
+            return MemoryLayout<UInt64>.stride
+        case .float:
+            return MemoryLayout<Float>.stride
+        case .double:
+            return MemoryLayout<Double>.stride
+        case .boolean:
+            return MemoryLayout<Bool>.stride
+        case .date32:
+            return MemoryLayout<Date32>.stride
+        case .date64:
+            return MemoryLayout<Date64>.stride
+        case .time32:
+            return MemoryLayout<Time32>.stride
+        case .time64:
+            return MemoryLayout<Time64>.stride
+        case .binary:
+            return MemoryLayout<Int8>.stride
+        case .string:
+            return MemoryLayout<Int8>.stride
+        default:
+            fatalError("Stride requested for unknown type: \(self)")
         }
     }
 }

--- a/swift/Arrow/Sources/Arrow/ProtoUtil.swift
+++ b/swift/Arrow/Sources/Arrow/ProtoUtil.swift
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import Foundation
+
+func fromProto( // swiftlint:disable:this cyclomatic_complexity
+    field: org_apache_arrow_flatbuf_Field
+) -> ArrowField {
+    let type = field.typeType
+    var arrowType = ArrowType(ArrowType.ArrowUnknown)
+    switch type {
+    case .int:
+        let intType = field.type(type: org_apache_arrow_flatbuf_Int.self)!
+        let bitWidth = intType.bitWidth
+        if bitWidth == 8 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt8 : ArrowType.ArrowUInt8)
+        } else if bitWidth == 16 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt16 : ArrowType.ArrowUInt16)
+        } else if bitWidth == 32 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt32 : ArrowType.ArrowUInt32)
+        } else if bitWidth == 64 {
+            arrowType = ArrowType(intType.isSigned ? ArrowType.ArrowInt64 : ArrowType.ArrowUInt64)
+        }
+    case .bool:
+        arrowType = ArrowType(ArrowType.ArrowBool)
+    case .floatingpoint:
+        let floatType = field.type(type: org_apache_arrow_flatbuf_FloatingPoint.self)!
+        if floatType.precision == .single {
+            arrowType = ArrowType(ArrowType.ArrowFloat)
+        } else if floatType.precision == .double {
+            arrowType = ArrowType(ArrowType.ArrowDouble)
+        }
+    case .utf8:
+        arrowType = ArrowType(ArrowType.ArrowString)
+    case .binary:
+        arrowType = ArrowType(ArrowType.ArrowBinary)
+    case .date:
+        let dateType = field.type(type: org_apache_arrow_flatbuf_Date.self)!
+        if dateType.unit == .day {
+            arrowType = ArrowType(ArrowType.ArrowDate32)
+        } else {
+            arrowType = ArrowType(ArrowType.ArrowDate64)
+        }
+    case .time:
+        let timeType = field.type(type: org_apache_arrow_flatbuf_Time.self)!
+        if timeType.unit == .second || timeType.unit == .millisecond {
+            let arrowUnit: ArrowTime32Unit = timeType.unit == .second ? .seconds : .milliseconds
+            arrowType = ArrowTypeTime32(arrowUnit)
+        } else {
+            let arrowUnit: ArrowTime64Unit = timeType.unit == .microsecond ? .microseconds : .nanoseconds
+            arrowType = ArrowTypeTime64(arrowUnit)
+        }
+    default:
+        arrowType = ArrowType(ArrowType.ArrowUnknown)
+    }
+
+    return ArrowField(field.name ?? "", type: arrowType, isNullable: field.nullable)
+}

--- a/swift/Arrow/Tests/ArrowTests/ArrayTests.swift
+++ b/swift/Arrow/Tests/ArrowTests/ArrayTests.swift
@@ -211,4 +211,38 @@ final class ArrayTests: XCTestCase {
         XCTAssertEqual(microArray[1], 20000)
         XCTAssertEqual(microArray[2], 987654321)
     }
+
+    func checkHolderForType(_ checkType: ArrowType) throws {
+        let buffers = [ArrowBuffer(length: 0, capacity: 0,
+                                rawPointer: UnsafeMutableRawPointer.allocate(byteCount: 0, alignment: .zero)),
+                       ArrowBuffer(length: 0, capacity: 0,
+                               rawPointer: UnsafeMutableRawPointer.allocate(byteCount: 0, alignment: .zero))]
+        let field = ArrowField("", type: checkType, isNullable: true)
+        switch makeArrayHolder(field, buffers: buffers, nullCount: 0) {
+        case .success(let holder):
+            XCTAssertEqual(holder.type.id, checkType.id)
+        case .failure(let err):
+            throw err
+        }
+    }
+
+    func testArrayHolders() throws {
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt8))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt8))
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt16))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt16))
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt32))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt32))
+        try checkHolderForType(ArrowType(ArrowType.ArrowInt64))
+        try checkHolderForType(ArrowType(ArrowType.ArrowUInt64))
+        try checkHolderForType(ArrowTypeTime32(.seconds))
+        try checkHolderForType(ArrowTypeTime32(.milliseconds))
+        try checkHolderForType(ArrowTypeTime64(.microseconds))
+        try checkHolderForType(ArrowTypeTime64(.nanoseconds))
+        try checkHolderForType(ArrowType(ArrowType.ArrowBinary))
+        try checkHolderForType(ArrowType(ArrowType.ArrowFloat))
+        try checkHolderForType(ArrowType(ArrowType.ArrowDouble))
+        try checkHolderForType(ArrowType(ArrowType.ArrowBool))
+        try checkHolderForType(ArrowType(ArrowType.ArrowString))
+    }
 }


### PR DESCRIPTION
WIP PR showing working consumption of nested avro complex types in avro to arrow conversion.

Basic idea is that for complex types, we should defer capacity calculations/validation to the consumers of the nested types.

I'm pretty sure that this doesn't cover all cases but I wanted to put it up for discussion.

