### PR TITLE
defer vector capacity checks for nested complex types

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroArraysConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroArraysConsumer.java
@@ -19,7 +19,12 @@ package org.apache.arrow.adapter.avro.consumers;
 
 import java.io.IOException;
 
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.AbstractContainerVector;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.RepeatedValueVector;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -67,8 +72,12 @@ public class AvroArraysConsumer extends BaseAvroConsumer<ListVector> {
   }
 
   void ensureInnerVectorCapacity(long targetCapacity) {
-    while (vector.getDataVector().getValueCapacity() < targetCapacity) {
-      vector.getDataVector().reAlloc();
+    FieldVector elementVec = vector.getDataVector();
+    if (!(elementVec instanceof RepeatedValueVector
+            || elementVec instanceof AbstractContainerVector)) {
+      while (vector.getDataVector().getValueCapacity() < targetCapacity) {
+        vector.getDataVector().reAlloc();
+      }
     }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroStructConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/adapter/avro/consumers/AvroStructConsumer.java
@@ -21,7 +21,10 @@ import java.io.IOException;
 
 import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.complex.AbstractContainerVector;
+import org.apache.arrow.vector.complex.RepeatedValueVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.types.Types;
 import org.apache.avro.io.Decoder;
 
 /**
@@ -68,8 +71,11 @@ public class AvroStructConsumer extends BaseAvroConsumer<StructVector> {
 
   void ensureInnerVectorCapacity(long targetCapacity) {
     for (FieldVector v : vector.getChildrenFromFields()) {
-      while (v.getValueCapacity() < targetCapacity) {
-        v.reAlloc();
+      if (!(v instanceof RepeatedValueVector
+              || v instanceof AbstractContainerVector)) {
+        while (v.getValueCapacity() < targetCapacity) {
+          v.reAlloc();
+        }
       }
     }
   }

--- a/java/adapter/avro/src/test/resources/schema/test_nested_union.avsc
+++ b/java/adapter/avro/src/test/resources/schema/test_nested_union.avsc
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+  "namespace": "org.apache.arrow.avro",
+  "type": "record",
+  "name": "testArrayOfRecords",
+  "fields": [
+    {
+      "name": "f0",
+      "type": {
+        "type": "record",
+        "name": "NestedRecord",
+        "fields": [
+          {
+            "name": "fUnionInRecord",
+            "type": ["null", "int"],
+            "default": null
+          },
+          {
+            "name": "fUnionInArray",
+            "type" : {
+              "type": "array",
+              "items": [
+                "null",
+                "int"
+              ]
+            }
+          },
+          {
+            "name": "fUnionInArrayOfRecords",
+            "type" : {
+              "type": "array",
+              "items": {
+                "type": "record",
+                "name": "RecordWithUnionField",
+                "fields": [
+                  {
+                    "name": "f1",
+                    "type": [
+                      "null",
+                      "int"
+                    ],
+                    "default": null
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
WIP PR showing working consumption of nested avro complex types in avro to arrow conversion.

Basic idea is that for complex types, we should defer capacity calculations/validation to the consumers of the nested types.

I'm pretty sure that this doesn't cover all cases but I wanted to put it up for discussion.

Related to https://github.com/apache/arrow-java/issues/131